### PR TITLE
Fix FBX export race conditions

### DIFF
--- a/AssetStudio.FBXWrapper/Fbx.cs
+++ b/AssetStudio.FBXWrapper/Fbx.cs
@@ -7,6 +7,7 @@ namespace AssetStudio
 {
     public static partial class Fbx
     {
+        private static readonly object ExportLock = new object();
 
         static Fbx()
         {
@@ -29,26 +30,34 @@ namespace AssetStudio
         {
             public static void Export(string path, IImported imported, ExportOptions exportOptions)
             {
-                var file = new FileInfo(path);
-                var dir = file.Directory;
-
-                if (!dir.Exists)
+                lock (ExportLock)
                 {
-                    dir.Create();
+                    var file = new FileInfo(path);
+                    var dir = file.Directory;
+
+                    if (!dir.Exists)
+                    {
+                        dir.Create();
+                    }
+
+                    var currentDir = Directory.GetCurrentDirectory();
+                    try
+                    {
+                        Directory.SetCurrentDirectory(dir.FullName);
+
+                        var name = Path.GetFileName(path);
+
+                        using (var exporter = new FbxExporter(name, imported, exportOptions))
+                        {
+                            exporter.Initialize();
+                            exporter.ExportAll();
+                        }
+                    }
+                    finally
+                    {
+                        Directory.SetCurrentDirectory(currentDir);
+                    }
                 }
-
-                var currentDir = Directory.GetCurrentDirectory();
-                Directory.SetCurrentDirectory(dir.FullName);
-
-                var name = Path.GetFileName(path);
-
-                using (var exporter = new FbxExporter(name, imported, exportOptions))
-                {
-                    exporter.Initialize();
-                    exporter.ExportAll();
-                }
-
-                Directory.SetCurrentDirectory(currentDir);
             }
         }
 


### PR DESCRIPTION
•	Added a global lock in Fbx.cs (Export(string, IImported, ExportOptions)) to serialize FBX export execution.
•	Wrapped working-directory switching with try/finally to always restore the previous directory.
Why
•	FBX export was running from parallel callers while using Directory.SetCurrentDirectory(...) (process-wide state), causing race conditions.
•	This reduces native FBX initialization/export instability (AccessViolationException) seen during concurrent exports.